### PR TITLE
Converted all classes, and test-suites, to ES6.

### DIFF
--- a/assets/js/package.json
+++ b/assets/js/package.json
@@ -3,8 +3,9 @@
   "version": "1.0.0",
   "description": "Week 04 - Cyber Pet Challenge",
   "main": "index.js",
+  "type": "module",
   "scripts": {
-    "test": "jest"
+    "test": "node --experimental-vm-modules ./node_modules/jest/bin/jest.js"
   },
   "imports": {
     "#~/*": "./*"

--- a/assets/js/src/objects/Creature.js
+++ b/assets/js/src/objects/Creature.js
@@ -1,11 +1,11 @@
-require('#~/src/prototype');
-const { Statistic } = require('./Statistic');
+import '#~/src/prototype';
+import { Statistic } from './Statistic';
 
 /**
  * Acts as a base class for all creatures provided as choices for the game.
  * @class
  */
-class Creature
+export class Creature
 {
     /**
      * @type {Object}
@@ -104,7 +104,3 @@ class Creature
         return this[this.#_options.maxTime];
     }
 }
-
-module.exports = {
-    Creature
-};

--- a/assets/js/src/objects/DecoratorCrab.js
+++ b/assets/js/src/objects/DecoratorCrab.js
@@ -1,4 +1,4 @@
-const { Creature } = require('./Creature');
+import { Creature } from './Creature';
 
 const options = {
     creatureType: "crab",
@@ -16,7 +16,7 @@ const options = {
  * Camouflage: The Decorator Crab is known for its ability to camouflage itself
  * by attaching bits of algae, seaweed, sponges, or other materials to its shell.
  */
-class DecoratorCrab extends Creature
+export class DecoratorCrab extends Creature
 {
     /**
      * Initialises a new instance of the {@link DecoratorCrab} class.
@@ -29,8 +29,4 @@ class DecoratorCrab extends Creature
     }
 }
 
-module.exports = {
-    DecoratorCrab
-};
-
-module.exports._options = options;
+export const _options = options;

--- a/assets/js/src/objects/MantisShrimp.js
+++ b/assets/js/src/objects/MantisShrimp.js
@@ -1,4 +1,4 @@
-const { Creature } = require('./Creature');
+import { Creature } from './Creature';
 
 const options = {
     creatureType: "shrimp",
@@ -17,7 +17,7 @@ const options = {
  * punches in the animal kingdom. It can strike its prey with a speed of 50 miles per
  * hour, which is strong enough to break glass or crack open a snail's shell.
  */
-class MantisShrimp extends Creature
+export class MantisShrimp extends Creature
 {
     /**
      * Initialises a new instance of the {@link MantisShrimp} class.
@@ -30,8 +30,4 @@ class MantisShrimp extends Creature
     }
 }
 
-module.exports = {
-    MantisShrimp
-};
-
-module.exports._options = options;
+export const _options = options;

--- a/assets/js/src/objects/Statistic.js
+++ b/assets/js/src/objects/Statistic.js
@@ -1,10 +1,10 @@
-require('#~/src/prototype');
+import '#~/src/prototype';
 
 /**
  * Represents a statistic that can be increased or decreased within a specified range.
  * @class
  */
-class Statistic
+export class Statistic
 {
     /**
      * @type {Number}
@@ -102,7 +102,3 @@ class Statistic
         this.#_currentValue = newValue.clamp(0, this.#_maxValue);
     }
 }
-
-module.exports = {
-    Statistic
-};

--- a/assets/js/src/objects/Sunfish.js
+++ b/assets/js/src/objects/Sunfish.js
@@ -1,4 +1,4 @@
-const { Creature } = require('./Creature');
+import { Creature } from './Creature';
 
 const options = {
     creatureType: "sunfish",
@@ -18,7 +18,7 @@ const options = {
  * is thought to help the fish regulate its body temperature and may also help
  * it remove parasites from its skin.
  */
-class Sunfish extends Creature
+export class Sunfish extends Creature
 {
     /**
      * Initialises a new instance of the {@link Sunfish} class.
@@ -31,8 +31,4 @@ class Sunfish extends Creature
     }
 }
 
-module.exports = {
-    Sunfish
-};
-
-module.exports._options = options;
+export const _options = options;

--- a/assets/js/src/objects/Triggerfish.js
+++ b/assets/js/src/objects/Triggerfish.js
@@ -1,4 +1,4 @@
-const { Creature } = require('./Creature');
+import { Creature } from './Creature';
 
 const options = {
     creatureType: "triggerfish",
@@ -16,7 +16,7 @@ const options = {
  * Trigger Attack:  The Picasso Triggerfish has strong, powerful jaws that it uses
  * to crush and eat hard-shelled prey such as crustaceans, snails, and sea urchins. 
  */
-class Triggerfish extends Creature
+export class Triggerfish extends Creature
 {
     /**
      * Initialises a new instance of the {@link Triggerfish} class.
@@ -29,8 +29,4 @@ class Triggerfish extends Creature
     }
 }
 
-module.exports = {
-    Triggerfish
-};
-
-module.exports._options = options;
+export const _options = options;

--- a/assets/js/src/prototype/index.js
+++ b/assets/js/src/prototype/index.js
@@ -1,1 +1,1 @@
-require('./Number.prototype');
+import './Number.prototype';

--- a/assets/js/tests/boilerplate.test.js
+++ b/assets/js/tests/boilerplate.test.js
@@ -1,5 +1,4 @@
-const assert = require('assert');
-// const { Class } = require('#~/src/objects/Class');
+// import { Class } from '#~/src/objects/Class.js';
 
 /**
  * @memberof Jest

--- a/assets/js/tests/prototype/Number.prototype.test.js
+++ b/assets/js/tests/prototype/Number.prototype.test.js
@@ -1,5 +1,5 @@
-const assert = require('assert');
-require('#~/src/prototype/Number.prototype.js');
+import '#~/src/prototype';
+import assert from 'assert';
 
 /**
  * @memberof Jest

--- a/assets/js/tests/src/objects/Creature.test.js
+++ b/assets/js/tests/src/objects/Creature.test.js
@@ -1,6 +1,5 @@
-require('#~/src/prototype');
-const assert = require('assert');
-const { Creature } = require('../../../src/objects/Creature');
+import '#~/src/prototype';
+import { Creature } from '../../../src/objects/Creature';
 
 /**
  * @memberof Jest

--- a/assets/js/tests/src/objects/DecoratorCrab.test.js
+++ b/assets/js/tests/src/objects/DecoratorCrab.test.js
@@ -1,6 +1,5 @@
-require('#~/src/prototype');
-const assert = require('assert');
-const { DecoratorCrab, _options } = require('../../../src/objects/DecoratorCrab');
+import '#~/src/prototype';
+import { DecoratorCrab, _options } from '../../../src/objects/DecoratorCrab';
 
 /**
  * @memberof Jest
@@ -8,6 +7,8 @@ const { DecoratorCrab, _options } = require('../../../src/objects/DecoratorCrab'
  */
 describe('DecoratorCrab', () =>
 {
+    let sut;
+
     beforeEach(() =>
     {
         sut = new DecoratorCrab("Bob");

--- a/assets/js/tests/src/objects/MantisShrimp.test.js
+++ b/assets/js/tests/src/objects/MantisShrimp.test.js
@@ -1,6 +1,5 @@
-require('#~/src/prototype');
-const assert = require('assert');
-const { MantisShrimp, _options } = require('../../../src/objects/MantisShrimp');
+import '#~/src/prototype';
+import { MantisShrimp, _options } from '../../../src/objects/MantisShrimp';
 
 /**
  * @memberof Jest
@@ -8,6 +7,8 @@ const { MantisShrimp, _options } = require('../../../src/objects/MantisShrimp');
  */
 describe('MantisShrimp', () =>
 {
+    let sut;
+
     beforeEach(() =>
     {
         sut = new MantisShrimp("Bob");

--- a/assets/js/tests/src/objects/Statistic.test.js
+++ b/assets/js/tests/src/objects/Statistic.test.js
@@ -1,4 +1,4 @@
-const { Statistic } = require('#~/src/objects/Statistic');
+import { Statistic } from '#~/src/objects/Statistic';
 
 /**
  * @memberof Jest

--- a/assets/js/tests/src/objects/Sunfish.test.js
+++ b/assets/js/tests/src/objects/Sunfish.test.js
@@ -1,6 +1,5 @@
-require('#~/src/prototype');
-const assert = require('assert');
-const { Sunfish, _options } = require('../../../src/objects/Sunfish');
+import '#~/src/prototype';
+import { Sunfish, _options } from '../../../src/objects/Sunfish';
 
 /**
  * @memberof Jest
@@ -8,6 +7,8 @@ const { Sunfish, _options } = require('../../../src/objects/Sunfish');
  */
 describe('Sunfish', () =>
 {
+    let sut;
+    
     beforeEach(() =>
     {
         sut = new Sunfish("Bob");

--- a/assets/js/tests/src/objects/Triggerfish.test.js
+++ b/assets/js/tests/src/objects/Triggerfish.test.js
@@ -1,6 +1,5 @@
-require('#~/src/prototype');
-const assert = require('assert');
-const { Triggerfish, _options } = require('../../../src/objects/Triggerfish');
+import '#~/src/prototype';
+import { Triggerfish, _options } from '../../../src/objects/Triggerfish';
 
 /**
  * @memberof Jest
@@ -8,6 +7,8 @@ const { Triggerfish, _options } = require('../../../src/objects/Triggerfish');
  */
 describe('Triggerfish', () =>
 {
+    let sut;
+    
     beforeEach(() =>
     {
         sut = new Triggerfish("Bob");


### PR DESCRIPTION
# Breaking Change

All Node style imports will now need to be changed to ES6 imports.

Replace your Node imports with this:

```
import './src/prototype';
import { MantisShrimp } from './src/objects/MantisShrimp';
import { DecoratorCrab } from './src/objects/DecoratorCrab';
import { Triggerfish } from './src/objects/Triggerfish';
import { Sunfish } from './src/objects/Sunfish';
```